### PR TITLE
feat: add test_shell parser

### DIFF
--- a/test_shell.py
+++ b/test_shell.py
@@ -1,3 +1,6 @@
+import shlex
+
+
 class TestShellApp:
     def read(self, address: int):
         pass
@@ -12,13 +15,60 @@ class TestShellApp:
         pass
 
     def exit(self):
-        pass
+        exit(0)
 
     def help(self):
         pass
 
-    def run(self):
-        pass
+    def run(self, max_iterations: int = None):
+        print(f"안녕하세요, SSD 검증용 Test Shell App을 시작합니다.\n")
+
+        while True:
+            if max_iterations is not None:
+                if max_iterations <= 0:
+                    break
+                max_iterations -= 1
+            command = input("Shell > ").strip()
+            parts = shlex.split(command)  # 공백을 기준으로 파싱하되 인용된 문자열도 처리
+            cmd_name, *cmd_args = parts
+            if self.is_validate_command(cmd_name, cmd_args):
+                if cmd_name == "exit":
+                    self.exit()
+                elif cmd_name == "help":
+                    self.help()
+                elif cmd_name == "write":
+                    self.write(cmd_args[0], cmd_args[1])
+                elif cmd_name == "read":
+                    self.read(cmd_args[0])
+                elif cmd_name == "fullwrite":
+                    self.full_write(cmd_args[0])
+                elif cmd_name == "fullread":
+                    self.full_read()
+                else:
+                    self.print_invalid_command()
+
+    def is_validate_command(self, cmd_name, cmd_args):
+        if cmd_name == "exit" or cmd_name == "help" or cmd_name == "fullread":
+            if len(cmd_args) > 0:
+                self.print_invalid_command()
+                return False
+        elif cmd_name == "write":
+            if len(cmd_args) != 2:
+                self.print_invalid_command()
+                return False
+        elif cmd_name == "read":
+            if len(cmd_args) != 1:
+                self.print_invalid_command()
+                return False
+        elif cmd_name == "fullwrite":
+            if len(cmd_args) != 1:
+                self.print_invalid_command()
+                return False
+
+        return True
+
+    def print_invalid_command(self):
+        print("INVALID COMMAND")
 
 
 if __name__ == "__main__":

--- a/tests/test_test_shell.py
+++ b/tests/test_test_shell.py
@@ -1,77 +1,131 @@
 import pytest
+from pytest_mock import MockerFixture
+from test_shell import TestShellApp
 
 
+@pytest.fixture
+def shell_app():
+    test_shell_app = TestShellApp()
+    return test_shell_app
+
+
+@pytest.mark.skip
 def test_shell_write():
     pass
 
 
+@pytest.mark.skip
 def test_shell_write_subprocess():
     pass
 
 
+@pytest.mark.skip
 def test_shell_write_wrong_address():
     pass
 
 
+@pytest.mark.skip
 def test_shell_write_wrong_data_format():
     pass
 
 
+@pytest.mark.skip
 def test_shell_write_short_number():
     pass
 
 
+@pytest.mark.skip
 def test_shell_read():
     pass
 
 
+@pytest.mark.skip
 def test_shell_read_wrong_address():
     pass
 
 
+@pytest.mark.skip
 def test_shell_read_output_file():
     pass
 
 
+@pytest.mark.skip
 def test_shell_read_after_write():
     pass
 
 
+@pytest.mark.skip
 def test_shell_read_after_read():
     pass
 
 
-def test_shell_wrong_cmd():
-    pass
+@pytest.mark.parametrize("input", ["exi", "rea", "wri", "hel"])
+def test_shell_wrong_cmd(shell_app, mocker: MockerFixture, input, capsys):
+    mocker.patch("builtins.input", side_effect=[input])
+
+    shell_app.run(1)
+    captured = capsys.readouterr()
+
+    assert 'INVALID COMMAND' in captured.out
 
 
-def test_shell_wrong_cmd_format():
-    pass
+@pytest.mark.skip
+def test_shell_wrong_cmd_empty(shell_app, mocker: MockerFixture, capsys):
+    mocker.patch("builtins.input", side_effect=[""])
+
+    shell_app.run(1)
+    captured = capsys.readouterr()
+
+    assert 'INVALID COMMAND' in captured.out
 
 
-def test_shell_wrong_cmd_args():
-    pass
+@pytest.mark.parametrize("input", ["read 1 2", "write", "fullwrite", "exit 3"])
+def test_shell_wrong_cmd_args(shell_app, mocker: MockerFixture, input, capsys):
+    mocker.patch("builtins.input", side_effect=["read 1 2"])
+
+    shell_app.run(1)
+    captured = capsys.readouterr()
+
+    assert 'INVALID COMMAND' in captured.out
 
 
+@pytest.mark.skip
 def test_shell_subprocess_cmd():
     pass
 
 
-def test_shell_exit():
-    pass
+# @pytest.mark.skip
+def test_shell_exit(shell_app, mocker: MockerFixture):
+    mocker.patch("builtins.input", side_effect=["exit"])
+    exit_mock = mocker.patch("test_shell.TestShellApp.exit", side_effect=SystemExit(0))
+
+    with pytest.raises(SystemExit) as e:
+        shell_app.run(1)
+
+    exit_mock.assert_called_once()
+    assert e.value.code == 0
 
 
-def test_shell_help():
-    pass
+@pytest.mark.skip
+def test_shell_help(shell_app, mocker: MockerFixture, capsys):
+    mocker.patch("builtins.input", side_effect=["help"])
+
+    shell_app.run()
+    captured = capsys.readouterr()
+
+    assert "종료합니다." in captured.out
 
 
+@pytest.mark.skip
 def test_shell_full_read():
     pass
 
 
+@pytest.mark.skip
 def test_shell_full_write():
     pass
 
 
+@pytest.mark.skip
 def test_shell_full_write_wrong_format():
     pass


### PR DESCRIPTION
### 📌 변경 내용
- test shell app의 parser 부분을 추가했습니다.

### 🔍 변경 이유
- test shell application에서 사용자 입력을 받고 명령을 수행하기 위해 필요합니다.

### 🧪 테스트 방법
- CMD가 붙은 테스트 케이스로 테스트 했으며, 존재하지 않는 커맨드, 잘못된 argument, 빈 커맨드를 테스트했습니다.

### ⚠️ 리뷰 시 중점적으로 볼 부분
- 특정 구현, 논의가 필요한 부분 등(optional)
