### PR TITLE
[feature] add write for test and fix init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# ssd files
+ssd_nand.txt
+ssd_output.txt
+
 # C extensions
 *.so
 

--- a/ssd.py
+++ b/ssd.py
@@ -9,16 +9,24 @@ ERROR_STRING = 'ERROR'
 
 class SSD:
     def __init__(self):
-        self.init_file(OUTPUT_FILE)
-        self.init_file(TARGET_FILE)
-        pass
+        self.init_output_file(OUTPUT_FILE)
+        self.init_target_file(TARGET_FILE)
 
-    def init_file(self, filename: str):
+    def init_target_file(self, filename: str):
         # 파일이 없으면 새로 생성
         # 100칸이 있어야 하므로 100개의 BLANK VALUE 생성
-        if not os.path.exists(filename):
-            with open(filename, "w") as f:
-                [f.write(BLANK_STRING + "\n") for _ in range(100)]
+        if os.path.exists(filename):
+            os.remove(filename)
+        with open(filename, "w") as f:
+            [f.write(BLANK_STRING + "\n") for _ in range(100)]
+        return
+
+    def init_output_file(self, filename: str):
+        # 파일이 없으면 새로 생성
+        if os.path.exists(filename):
+            os.remove(filename)
+        with open(filename, "w") as f:
+            f.write("")
         return
 
     def read(self, address: int) -> int:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -11,6 +11,21 @@ def get_output_file() -> str:
         content_string = f.read()
     return content_string.rstrip("\n")
 
+def write_file(address:int, value: str):
+    ssd = SSD()
+    if address < 0 or address > 100:
+        with open(OUTPUT_FILE, "w") as f:
+            f.write(ERROR_STRING + "\n")
+    with open(TARGET_FILE, "r") as f:
+        lines = f.readlines()
+    # 줄이 address 줄보다 적으면 빈 줄로 채움
+    while len(lines) < address:
+        lines.append("\n")
+    lines[address] = value + "\n"
+    with open(TARGET_FILE, "w") as f:
+        f.writelines(lines)
+    return 0
+
 def test_read_file_exist():
     ssd = SSD()
     if os.path.exists(TARGET_FILE):
@@ -22,23 +37,23 @@ def test_read_file_exist():
 
 def test_write_file_exist():
     ssd = SSD()
-    if os.path.exists(WRITE_FILE):
-        os.remove(WRITE_FILE)
-    assert not os.path.exists(WRITE_FILE)
+    if os.path.exists(TARGET_FILE):
+        os.remove(TARGET_FILE)
+    assert not os.path.exists(TARGET_FILE)
     ssd.write(0,"00")
-    assert os.path.exists(WRITE_FILE)
-    os.remove(WRITE_FILE)
+    assert os.path.exists(TARGET_FILE)
+    os.remove(TARGET_FILE)
 
 
 def test_read_success_lba0():
     ssd = SSD()
-    ssd.write(0, TEST_VALUE)
+    write_file(0, TEST_VALUE)
     ssd.read(0)
     assert get_output_file() == TEST_VALUE
 
 def test_read_success_lba99():
     ssd = SSD()
-    ssd.write(99, TEST_VALUE)
+    write_file(99, TEST_VALUE)
     ssd.read(99)
     assert get_output_file() == TEST_VALUE
 
@@ -54,9 +69,9 @@ def test_read_blank_success():
 def test_read_lba_error():
     ssd = SSD()
     ssd.read(-1)
-    assert get_output_file() == ERROR_VALUE
+    assert get_output_file() == ERROR_STRING
 
 def test_read_invalid_lba_error():
     ssd = SSD()
     ssd.read('A')
-    assert get_output_file() == ERROR_VALUE
+    assert get_output_file() == ERROR_STRING


### PR DESCRIPTION
### 📌 변경 내용
- write 함수를 test 파일에서 따로 구현해서 수행하도록 변경
- init 시에 기존의 파일은 깔끔하게 지우도록 변경
- output은 ""으로 init, target 은 0x000000 100줄로 init하도록 변경

### 🔍 변경 이유
- ssd의 write함수 의존성을 제거하기 위해 test에서 자체적으로 write해서 테스트하도록 변경
- init시 output이랑 target이 다르게 만들어져야 해서 분리

### 🧪 테스트 방법
- 기존의 read lba0, read lba99 함수 테스트 성공

### ⚠️ 리뷰 시 중점적으로 볼 부분
- init 방식 이렇게 하는게 괜찮을지 검토 부탁드립니다!
