### PR TITLE
[bugFix] return ERROR when test scripts are failed

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -143,7 +143,7 @@ class TestShellApp:
             for address in range(block, block + 5):
                 if self._read_and_compare(str(address), write_value) == False:
                     print("FAIL")
-                    raise SystemExit(1)
+                    return ERROR
         print("PASS")
         return SUCCESS
 
@@ -157,7 +157,7 @@ class TestShellApp:
             for address in range(0, 5):
                 if self._read_and_compare(str(address), "0x12345678") == False:
                     print("FAIL")
-                    raise SystemExit(1)
+                    return ERROR
         print("PASS")
         return SUCCESS
 
@@ -170,10 +170,10 @@ class TestShellApp:
 
             if self._read_and_compare("0", write_value) == False:
                 print("FAIL")
-                raise SystemExit(1)
+                return ERROR
             if self._read_and_compare("99", write_value) == False:
                 print("FAIL")
-                raise SystemExit(1)
+                return ERROR
         print("PASS")
         return SUCCESS
 


### PR DESCRIPTION
### 📌 변경 내용
- test scripts fail시에 error를 return하도록 변경

### 🔍 변경 이유
- 기존에는 shell을 종료시켰는데, error를 return하도록 변경 필요

### 🧪 테스트 방법
- fail시에 error return하여 INVALID COMMAND 출력 확인

### ⚠️ 리뷰 시 중점적으로 볼 부분
- 특정 구현, 논의가 필요한 부분 등(optional)
