### PR TITLE
[Feature] shell erase cmd 기능 추가

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -19,8 +19,8 @@ MAX_ERASE_SIZE = 10
 
 
 class SSDDriver:
-    def run_ssd_write(self, address: str, lba_size: str):
-        command = ['python', 'ssd.py', 'W', str(address), str(lba_size)]
+    def run_ssd_write(self, address: str, value: str):
+        command = ['python', 'ssd.py', 'W', str(address), str(value)]
         result = subprocess.run(command, cwd=ROOT_DIR, capture_output=True, text=True)
 
         if result.returncode == 0:

--- a/shell.py
+++ b/shell.py
@@ -139,11 +139,8 @@ class TestShellApp:
         return WRITE_SUCCESS
 
     def erase(self, address: str, lba_size: str):
-        # lba_size 검증 추가
-        if not self.is_address_valid(address) :
+        if not self.is_address_valid(address) or not self.is_size_valid(lba_size) :
             return ERASE_ERROR
-        # if not self.is_size_valid(lba_size):
-        #     return ERASE_ERROR
 
         ret = self._ssd_driver.run_ssd_erase(address=address, lba_size=lba_size)
         return ret
@@ -294,7 +291,14 @@ class TestShellApp:
         print("INVALID COMMAND")
 
     def is_size_valid(self, lba_size):
-        pass
+        try:
+            lba_size = int(lba_size)
+            return True
+        except ValueError:
+            return False  # 정수형으로 변환할 수 없는 경우 (예: "0.5")
+
+
+
 
 
 if __name__ == "__main__":

--- a/shell.py
+++ b/shell.py
@@ -69,6 +69,7 @@ class TestShellApp:
             "write": (2, lambda args: self.write(args[0], args[1])),
             "read": (1, lambda args: self.read(args[0])),
             "erase": (2, lambda args: self.erase(args[0], args[1])),
+            "erase_range": (2, lambda args: self.erase_range(args[0], args[1])),
             "fullwrite": (1, lambda args: self.full_write(args[0])),
             "1_": (0, lambda: self.full_write_and_read_compare()),
             "1_FullWriteAndReadCompare": (0, lambda: self.full_write_and_read_compare()),
@@ -312,7 +313,7 @@ class TestShellApp:
             return
 
         try:
-            if cmd_name in ["write", "erase"]:
+            if cmd_name in ["write", "erase", "erase_range"]:
                 ret = handler(cmd_args)
                 if ret == SUCCESS:
                     print(f"[{cmd_name.capitalize()}] Done")

--- a/shell.py
+++ b/shell.py
@@ -10,18 +10,29 @@ WRITE_SUCCESS = SUCCESS
 WRITE_ERROR = ERROR
 READ_SUCCESS = SUCCESS
 READ_ERROR = ERROR
+ERASE_SUCCESS = SUCCESS
+ERASE_ERROR = ERROR
 ROOT_DIR = os.path.dirname(__file__)
 
 
 class SSDDriver:
-    def run_ssd_write(self, address: str, value: str):
-        command = ['python', 'ssd.py', 'W', str(address), str(value)]
+    def run_ssd_write(self, address: str, lba_size: str):
+        command = ['python', 'ssd.py', 'W', str(address), str(lba_size)]
         result = subprocess.run(command, cwd=ROOT_DIR, capture_output=True, text=True)
 
         if result.returncode == 0:
             return WRITE_SUCCESS
         else:
             return WRITE_ERROR
+
+    def run_ssd_erase(self, address: str, lba_size: str):
+        command = ['python', 'ssd.py', 'E', str(address), str(lba_size)]
+        result = subprocess.run(command, cwd=ROOT_DIR, capture_output=True, text=True)
+
+        if result.returncode == 0:
+            return ERASE_SUCCESS
+        else:
+            return ERASE_ERROR
 
     def run_ssd_read(self, address: str):
         command = ['python', 'ssd.py', 'R', str(address)]
@@ -126,6 +137,16 @@ class TestShellApp:
             if self._ssd_driver.run_ssd_write(address=str(address), value=formatted_value) == WRITE_ERROR:
                 return WRITE_ERROR
         return WRITE_SUCCESS
+
+    def erase(self, address: str, lba_size: str):
+        # lba_size 검증 추가
+        if not self.is_address_valid(address) :
+            return ERASE_ERROR
+        # if not self.is_size_valid(lba_size):
+        #     return ERASE_ERROR
+
+        ret = self._ssd_driver.run_ssd_erase(address=address, lba_size=lba_size)
+        return ret
 
     def _read_and_compare(self, address: str, written_value: str):
         read_status = self.read(address)
@@ -271,6 +292,9 @@ class TestShellApp:
 
     def print_invalid_command(self):
         print("INVALID COMMAND")
+
+    def is_size_valid(self, lba_size):
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -59,6 +59,7 @@ def test_shell_write_test_valid_address(shell_app, valid_address):
     assert ret == WRITE_SUCCESS
     shell_app._ssd_driver.run_ssd_write.assert_called_once_with(address=valid_address, value="0x00000001")
 
+
 @pytest.mark.parametrize("valid_value", ["0xa", "0xab", "0xabc", "0xabcd", "0xabcde", "0xabcdef", "0xabcdeff"])
 def test_shell_write_valid_value(shell_app, valid_value):
     # Arrange
@@ -385,5 +386,4 @@ def test_shell_erase_resize(shell_app):
 
     # Assert
     assert ERASE_SUCCESS == ret_pass
-    shell_app._ssd_driver.run_ssd_write.assert_called_once_with(address="0", lba_size="100")
-
+    shell_app._ssd_driver.run_ssd_erase.assert_called_once_with(address="0", lba_size="100")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -387,7 +387,7 @@ def test_shell_erase_resize(shell_app, mocker):
 
     # Assert
     assert ERASE_SUCCESS == ret_pass
-    shell_app._erase_in_chunks.assert_called_once_with(start=0, size=100)
+    shell_app._erase_in_chunks.assert_called_once_with(start_lba=0, size=100)
 
 
 def test_shell_erase_resize_minus(shell_app, mocker):
@@ -400,4 +400,28 @@ def test_shell_erase_resize_minus(shell_app, mocker):
 
     # Assert
     assert ERASE_SUCCESS == ret_pass
-    shell_app._erase_in_chunks.assert_called_once_with(start=11, size=20)
+    shell_app._erase_in_chunks.assert_called_once_with(start_lba=11, size=20)
+
+def test_shell_erase_range(shell_app, mocker):
+    # Arrange
+    shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
+    mocker.patch.object(shell_app, "_erase_in_chunks", return_value=ERASE_SUCCESS, )
+
+    # Act
+    ret_pass = shell_app.erase_range(start_lba="31", end_lba="60")
+
+    # Assert
+    assert ERASE_SUCCESS == ret_pass
+    shell_app._erase_in_chunks.assert_called_once_with(start_lba=31, size=30)
+
+def test_shell_erase_range_reverse(shell_app, mocker):
+    # Arrange
+    shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
+    mocker.patch.object(shell_app, "_erase_in_chunks", return_value=ERASE_SUCCESS, )
+
+    # Act
+    ret_pass = shell_app.erase_range(start_lba="60", end_lba="31")
+
+    # Assert
+    assert ERASE_SUCCESS == ret_pass
+    shell_app._erase_in_chunks.assert_called_once_with(start_lba=31, size=30)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -377,13 +377,27 @@ def test_shell_erase(shell_app):
     assert ERASE_ERROR == ret_fail
 
 
-def test_shell_erase_resize(shell_app):
+def test_shell_erase_resize(shell_app, mocker):
     # Arrange
     shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
+    mocker.patch.object(shell_app, "_erase_in_chunks", return_value=ERASE_SUCCESS, )
 
     # Act
     ret_pass = shell_app.erase(address="0", lba_size="1000")
 
     # Assert
     assert ERASE_SUCCESS == ret_pass
-    #shell_app._ssd_driver.run_ssd_erase.assert_called_once_with(address="0", lba_size="100")
+    shell_app._erase_in_chunks.assert_called_once_with(start=0, size=100)
+
+
+def test_shell_erase_resize_minus(shell_app, mocker):
+    # Arrange
+    shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
+    mocker.patch.object(shell_app, "_erase_in_chunks", return_value=ERASE_SUCCESS, )
+
+    # Act
+    ret_pass = shell_app.erase(address="30", lba_size="-20")
+
+    # Assert
+    assert ERASE_SUCCESS == ret_pass
+    shell_app._erase_in_chunks.assert_called_once_with(start=11, size=20)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -386,4 +386,4 @@ def test_shell_erase_resize(shell_app):
 
     # Assert
     assert ERASE_SUCCESS == ret_pass
-    shell_app._ssd_driver.run_ssd_erase.assert_called_once_with(address="0", lba_size="100")
+    #shell_app._ssd_driver.run_ssd_erase.assert_called_once_with(address="0", lba_size="100")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -362,3 +362,14 @@ def test_shell_runner_with_wrong_testfile(shell_app, mocker: MockerFixture, caps
 
     # Assert
     assert "INVALID COMMAND" in capsys.readouterr().out
+
+def test_shell_erase(shell_app, mocker: MockerFixture):
+    # Arrange
+    shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
+
+    # Act
+    ret = shell_app.erase(address="0", lba_size="1")
+
+    # Assert
+    assert ERASE_SUCCESS == ret
+    shell_app._ssd_driver.run_ssd_erase.assert_called_once_with(address="0", lba_size="1")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -363,13 +363,27 @@ def test_shell_runner_with_wrong_testfile(shell_app, mocker: MockerFixture, caps
     # Assert
     assert "INVALID COMMAND" in capsys.readouterr().out
 
-def test_shell_erase(shell_app, mocker: MockerFixture):
+def test_shell_erase(shell_app):
     # Arrange
     shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
 
     # Act
-    ret = shell_app.erase(address="0", lba_size="1")
+    ret_pass = shell_app.erase(address="0", lba_size="1")
+    ret_fail = shell_app.erase(address="0", lba_size="0.5")
 
     # Assert
-    assert ERASE_SUCCESS == ret
-    shell_app._ssd_driver.run_ssd_erase.assert_called_once_with(address="0", lba_size="1")
+    assert ERASE_SUCCESS == ret_pass
+    assert ERASE_ERROR == ret_fail
+
+
+def test_shell_erase_resize(shell_app):
+    # Arrange
+    shell_app._ssd_driver.run_ssd_erase.return_value = ERASE_SUCCESS
+
+    # Act
+    ret_pass = shell_app.erase(address="0", lba_size="1000")
+
+    # Assert
+    assert ERASE_SUCCESS == ret_pass
+    shell_app._ssd_driver.run_ssd_write.assert_called_once_with(address="0", lba_size="100")
+


### PR DESCRIPTION
### 📌 변경 내용
- Shell에서 동작하는 erase , erase_range 커맨드 구현
- ssd에 erase 요청시 MAX_ERASE_SIZE = 10 맞추어 분할 요청 동작하도록 구현
- LBA 구간 초과시 조정하도록 구현(0~99범위내) 

### 🔍 변경 이유
- 추가 기능 요청으로 기능 추가

### 🧪 테스트 방법
- 기존 TC 확인, Test Double 활용하여 Erase 파라미터 처리 확인

### ⚠️ 리뷰 시 중점적으로 볼 부분
- pytest에서 제대로 동작되는지 확인해주시면 될 것 같습니다.
- 현재 SSD.py의 erase기능 구현 반영이 되진 않았으므로, Shell 실행시에는 INVALID COMMAND로 처리되게 됩니다.
